### PR TITLE
性能优化: 首页笔记本列表单次API获取 (Vibe Kanban)

### DIFF
--- a/backend/frontend/static/app.js
+++ b/backend/frontend/static/app.js
@@ -378,8 +378,8 @@ class OpenNotebook {
                 this.updateFooter();
             }
 
-            // 从服务器获取最新数据
-            const notebooks = await this.api('/notebooks');
+            // 从服务器获取最新数据（包含统计信息）
+            const notebooks = await this.api('/notebooks/stats');
             this.notebooks = notebooks;
 
             // 更新缓存
@@ -424,8 +424,10 @@ class OpenNotebook {
             card.dataset.id = nb.id;
             card.querySelector('.notebook-card-name').textContent = nb.name;
             card.querySelector('.notebook-card-desc').textContent = nb.description || '暂无描述';
-            
-            this.loadNotebookCardCounts(nb.id, card);
+
+            // 直接使用从 API 获取的统计信息
+            card.querySelector('.stat-sources').textContent = `${nb.source_count || 0} 来源`;
+            card.querySelector('.stat-notes').textContent = `${nb.note_count || 0} 笔记`;
 
             card.addEventListener('click', (e) => {
                 if (!e.target.closest('.btn-delete-card')) {
@@ -450,20 +452,6 @@ class OpenNotebook {
 
             container.appendChild(clone);
         });
-    }
-
-    async loadNotebookCardCounts(notebookId, element) {
-        try {
-            const [sources, notes] = await Promise.all([
-                this.api(`/notebooks/${notebookId}/sources`),
-                this.api(`/notebooks/${notebookId}/notes`)
-            ]);
-
-            element.querySelector('.stat-sources').textContent = `${sources.length} 来源`;
-            element.querySelector('.stat-notes').textContent = `${notes.length} 笔记`;
-        } catch (error) {
-            // 忽略错误
-        }
     }
 
     switchView(view) {

--- a/backend/server.go
+++ b/backend/server.go
@@ -106,6 +106,7 @@ func (s *Server) setupRoutes() {
 		notebooks := api.Group("/notebooks")
 		{
 			notebooks.GET("", s.handleListNotebooks)
+			notebooks.GET("/stats", s.handleListNotebooksWithStats)
 			notebooks.POST("", s.handleCreateNotebook)
 			notebooks.GET("/:id", s.handleGetNotebook)
 			notebooks.PUT("/:id", s.handleUpdateNotebook)
@@ -204,6 +205,16 @@ func (s *Server) handleListNotebooks(c *gin.Context) {
 	notebooks, err := s.store.ListNotebooks(ctx)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Failed to list notebooks"})
+		return
+	}
+	c.JSON(http.StatusOK, notebooks)
+}
+
+func (s *Server) handleListNotebooksWithStats(c *gin.Context) {
+	ctx := context.Background()
+	notebooks, err := s.store.ListNotebooksWithStats(ctx)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Failed to list notebooks with stats"})
 		return
 	}
 	c.JSON(http.StatusOK, notebooks)

--- a/backend/types.go
+++ b/backend/types.go
@@ -43,6 +43,18 @@ type Notebook struct {
 	Metadata    map[string]interface{} `json:"metadata,omitempty"`
 }
 
+// NotebookWithStats represents a notebook with statistics
+type NotebookWithStats struct {
+	ID          string                 `json:"id"`
+	Name        string                 `json:"name"`
+	Description string                 `json:"description,omitempty"`
+	CreatedAt   time.Time              `json:"created_at"`
+	UpdatedAt   time.Time              `json:"updated_at"`
+	Metadata    map[string]interface{} `json:"metadata,omitempty"`
+	SourceCount int                    `json:"source_count"`
+	NoteCount   int                    `json:"note_count"`
+}
+
 // ChatMessage represents a chat message
 type ChatMessage struct {
 	ID         string                 `json:"id"`


### PR DESCRIPTION
## 概述

优化首页笔记本列表加载性能，将 API 请求从 1 + 2N 个减少到 1 个（N 为笔记本数量）。

## 问题背景

原有实现中，首页加载笔记本列表时：
- 首先调用 GET /api/notebooks 获取所有笔记本
- 然后为每个笔记本卡片调用 loadNotebookCardCounts 方法
- 该方法对每个笔记本发起 2 个额外的 API 请求（sources 和 notes 统计）

这导致如果有 10 个笔记本，首页加载需要 21 个 API 请求，严重影响加载性能。

## 实施的改动

### 后端

1. 新增类型定义 (backend/types.go:46-56)
   - 添加 NotebookWithStats 结构体，包含 source_count 和 note_count 字段

2. 新增数据库方法 (backend/store.go:250-290)
   - 添加 ListNotebooksWithStats 方法
   - 使用单个 SQL 查询配合子查询，一次性获取所有笔记本及其统计信息

3. 新增 API 端点 (backend/server.go:109, 212-220)
   - 添加 GET /api/notebooks/stats 路由
   - 实现 handleListNotebooksWithStats 处理函数

### 前端

1. 修改数据获取 (backend/frontend/static/app.js:382)
   - loadNotebooks 方法改为调用 /notebooks/stats API

2. 优化渲染逻辑 (backend/frontend/static/app.js:428-430)
   - renderNotebookCards 直接使用 API 返回的统计信息
   - 移除了对 loadNotebookCardCounts 的异步调用

3. 删除冗余代码
   - 移除 loadNotebookCardCounts 方法（不再需要）

## 性能提升

| 笔记本数量 | 优化前请求数 | 优化后请求数 | 改善 |
|----------|------------|------------|------|
| 1        | 3          | 1          | 67%  |
| 10       | 21         | 1          | 95%  |
| 50       | 101        | 1          | 99%  |

## 实现细节

- 使用 SQL 子查询 (SELECT COUNT(*)...) 在单次查询中计算统计信息
- 保留了原有的 /notebooks 端点以确保向后兼容
- 前端缓存逻辑保持不变，继续使用 5 分钟 TTL

---

This PR was written using [Vibe Kanban](https://vibekanban.com)